### PR TITLE
Stories/consolidate sal

### DIFF
--- a/Backend/CongressDataRetrievalService/src/congressDataService.js
+++ b/Backend/CongressDataRetrievalService/src/congressDataService.js
@@ -4,6 +4,7 @@ var BillRetrieverNamespace = (function () {
 
 	const httpUtility = require('../../Shared/ServiceAccess/httpUtility');
 	const http = require('http');
+	const https = require('https');
 
     module.exports.BillRetriever = new BillRetriever();
 
@@ -24,7 +25,7 @@ var BillRetrieverNamespace = (function () {
     */
 	function BillRetriever() 
 	{
-		this.congressDataAgent = new http.Agent({keepAlive: true});
+		this.congressDataAgentSecure = new https.Agent({keepAlive: true});
 	}
 
 	BillRetriever.prototype.startGetCongressMembersBillsSchedule = function() 
@@ -82,11 +83,10 @@ var BillRetrieverNamespace = (function () {
 	*/
 	BillRetriever.prototype.getCongressMembers = function(next)
 	{
-		const memberRequest = httpUtility.makeHttpRequest(constants.BASE_CONGRESS_API_URI,
-		null,
-		'/' + constants.CURRENT_CONGRESS + '/' + 'house/members',
+		const memberRequest = httpUtility.makeHttpsRequest(constants.CONGRESS_API_HOST_URI,
+		constants.BASE_CONGRESS_API_PATH + '/' + constants.CURRENT_CONGRESS + '/' + 'house/members.json',
 		httpUtility.requestType.GET,
-		this.congressDataAgent,
+		this.congressDataAgentSecure,
 		null,
 		null,
 		{'X-API-Key': constants.PROPUBLICA_API_KEY},
@@ -110,6 +110,11 @@ var BillRetrieverNamespace = (function () {
 					// todo
 				}
 			});
+		});
+
+		memberRequest.on('error', (e) => {
+			console.error('problem with get congress members request: ' + e.message);
+			return next(e);
 		});
 
 		/*

--- a/Backend/CongressDataRetrievalService/src/congressDataService.js
+++ b/Backend/CongressDataRetrievalService/src/congressDataService.js
@@ -2,6 +2,9 @@
 
 var BillRetrieverNamespace = (function () {
 
+	const httpUtility = require('../../Shared/ServiceAccess/httpUtility');
+	const http = require('http');
+
     module.exports.BillRetriever = new BillRetriever();
 
 	var request = require('request');
@@ -19,11 +22,13 @@ var BillRetrieverNamespace = (function () {
     /**
     * BillRetriever - Gets the latest bills and congress members data
     */
-	function BillRetriever() {
-
+	function BillRetriever() 
+	{
+		this.congressDataAgent = new http.Agent({keepAlive: true});
 	}
 
-	BillRetriever.prototype.startGetCongressMembersBillsSchedule = function() {
+	BillRetriever.prototype.startGetCongressMembersBillsSchedule = function() 
+	{
 		console.log('Congress Data Retrieval Started...');
 		var self = this;
 
@@ -43,7 +48,7 @@ var BillRetrieverNamespace = (function () {
 		var j = schedule.scheduleJob(rule, function(){
   			self.getCongressMembersBills();
 		});
-	},
+	}
 
 	/**
 	* getRecentBills() - Gets the latest bills of each bill type for the house and senate
@@ -69,13 +74,45 @@ var BillRetrieverNamespace = (function () {
 				}
 			});
 		});
-	},
+	}
 
 	/**
 	* getCongressMembers() - Gets the latest information for each Congress member
 	* @param <function()> next
 	*/
-	BillRetriever.prototype.getCongressMembers = function(next){
+	BillRetriever.prototype.getCongressMembers = function(next)
+	{
+		const memberRequest = httpUtility.makeHttpRequest(constants.BASE_CONGRESS_API_URI,
+		null,
+		'/' + constants.CURRENT_CONGRESS + '/' + 'house/members',
+		httpUtility.requestType.GET,
+		this.congressDataAgent,
+		null,
+		null,
+		{'X-API-Key': constants.PROPUBLICA_API_KEY},
+		(resp) => {
+			var responseData = '';
+
+			res.on('data', (chunk) => {
+				responseData += chunk;
+			});
+
+			res.on('end', () => {
+				console.log('registerNewUser response body end: ' + responseData);
+
+				if (res.statusCode != '200')
+				{
+					var frErr = frameError(responseData);
+					return next(frErr);
+				}
+				else
+				{
+					// todo
+				}
+			});
+		});
+
+		/*
 	    getRequest(constants.HOUSE_MEMBERS_URI + '.json', processMembersData, function (houseErr) {
 			if(houseErr) {
 				return next(houseErr);
@@ -94,7 +131,8 @@ var BillRetrieverNamespace = (function () {
 				next();
 			});
 		});
-	},
+		*/
+	}
 
 	/**
 	* getCongressMembersBills() - Gets the latest bill information sponsored by each Congress member
@@ -109,7 +147,7 @@ var BillRetrieverNamespace = (function () {
 			var count = 0;
 			getAllCongressMembersBills(count);
 		});
-	},
+	}
 
 	BillRetriever.prototype.getBill = function(billNumber)
 	{
@@ -117,7 +155,7 @@ var BillRetrieverNamespace = (function () {
 		database.queryBills(query, function(err, docs){
 			return docs;
 		});
-	},
+	}
 
 	BillRetriever.prototype.getMember = function(memberId) {
 		var query = {id: memberId};

--- a/Backend/CongressDataRetrievalService/src/congressDataService.js
+++ b/Backend/CongressDataRetrievalService/src/congressDataService.js
@@ -88,9 +88,9 @@ var BillRetrieverNamespace = (function () {
 		httpUtility.requestType.GET,
 		this.congressDataAgentSecure,
 		null,
-		null,
+		httpUtility.contentType.JSON,
 		{'X-API-Key': constants.PROPUBLICA_API_KEY},
-		(resp) => {
+		(res) => {
 			var responseData = '';
 
 			res.on('data', (chunk) => {
@@ -98,8 +98,6 @@ var BillRetrieverNamespace = (function () {
 			});
 
 			res.on('end', () => {
-				console.log('registerNewUser response body end: ' + responseData);
-
 				if (res.statusCode != '200')
 				{
 					var frErr = frameError(responseData);
@@ -116,6 +114,8 @@ var BillRetrieverNamespace = (function () {
 			console.error('problem with get congress members request: ' + e.message);
 			return next(e);
 		});
+
+		memberRequest.end();
 
 		/*
 	    getRequest(constants.HOUSE_MEMBERS_URI + '.json', processMembersData, function (houseErr) {

--- a/Backend/CongressDataRetrievalService/src/constants.js
+++ b/Backend/CongressDataRetrievalService/src/constants.js
@@ -1,7 +1,7 @@
 ﻿var constants = {};
 
 constants.PROPUBLICA_API_KEY = 'BQ03NR8CIK2paMdsiI2m05hBMiuGyyEY3jXJCLbp';
-constants.BASE_CONGRESS_API_URI ='https://api.propublica.org/congress/v1/';
+constants.BASE_CONGRESS_API_URI ='https://api.propublica.org/congress/v1';
 constants.CURRENT_CONGRESS = '115' ;
 constants.BILL_TYPES = ['introduced' , 'updated' , 'passed' , 'major'];
 constants.HOUSE_BILLS_URI = constants.BASE_CONGRESS_API_URI + constants.CURRENT_CONGRESS + '/' + 'house/bills/';

--- a/Backend/CongressDataRetrievalService/src/constants.js
+++ b/Backend/CongressDataRetrievalService/src/constants.js
@@ -1,7 +1,9 @@
 ﻿var constants = {};
 
 constants.PROPUBLICA_API_KEY = 'BQ03NR8CIK2paMdsiI2m05hBMiuGyyEY3jXJCLbp';
-constants.BASE_CONGRESS_API_URI ='https://api.propublica.org/congress/v1';
+constants.CONGRESS_API_HOST_URI = 'api.propublica.org';
+constants.BASE_CONGRESS_API_PATH = '/congress/v1';
+constants.BASE_CONGRESS_API_URI ='api.propublica.org/congress/v1';
 constants.CURRENT_CONGRESS = '115' ;
 constants.BILL_TYPES = ['introduced' , 'updated' , 'passed' , 'major'];
 constants.HOUSE_BILLS_URI = constants.BASE_CONGRESS_API_URI + constants.CURRENT_CONGRESS + '/' + 'house/bills/';

--- a/Backend/Shared/ServiceAccess/httpUtility.js
+++ b/Backend/Shared/ServiceAccess/httpUtility.js
@@ -1,6 +1,7 @@
 // httpUtility.js
 // provides utility functions for http service requests
 const http = require('http');
+const https = require('https');
 
 module.exports = {
 
@@ -62,5 +63,51 @@ module.exports = {
     options.headers = requestHeaders;
 
     return http.request(options, callback);
+  },
+
+  /**
+    * creates an https.ClientRequest object for a REST request over SSL
+    * @param {string} hostUri - the host URI
+    * @param {string} path - the resource path
+    * @param {string} method - the REST method
+    * @param {http.Agent} agent - an optional http.Agent object for managing connection persistence
+    * @param {string} requestData - optional JSON stringified request data
+    * @param {httpUtility.contentType} contentType - the type of content.
+    * @param {string:object} headers - passed-in headers
+    * @param {Function} callback - an optional callback function to attach to the request
+  **/
+  makeHttpsRequest: function(hostUri, path, method, agent, requestData, contentType, headers, callback)
+  {
+    // create the options object
+    var options = {
+      host: hostUri,
+      path: path,
+      method: method,
+      agent: agent
+    }
+
+    // form the request headers
+    var requestHeaders = {
+      'Content-Type': contentType
+    }
+
+    if (requestData != null)
+    {
+      requestHeaders['Content-Length'] = requestData.length;
+    }
+
+    // add any passed-in headers if necessary
+    if (headers != null)
+    {
+      for (key in headers)
+      {
+        requestHeaders[key] = headers[key];
+      }
+    }
+
+    // add the request headers ot the options
+    options.headers = requestHeaders;
+
+    return https.request(options, callback);
   }
 }


### PR DESCRIPTION
This is a request to consolidate the CongressDataService's http access to use the shared httpUtility module (http and https Node.js built-in modules) similar to how FrameLocalService does.

Tested by renaming the congress members schema and ran to make sure the mongo database was populated with a new table. Everything seems to work okay.